### PR TITLE
Replace deprecated iwconfig with nmcli

### DIFF
--- a/wifi-fixer-bash-script.sh
+++ b/wifi-fixer-bash-script.sh
@@ -30,7 +30,7 @@ else
 fi
 
 # Check signal quality
-signal_quality=$(iwconfig $interface | awk '/Quality/ {print $2}' | cut -d= -f2)
+signal_quality=$(nmcli d wifi list ifname $interface | grep '*' | awk '{print $9}')/100
 echo "Signal quality is: $signal_quality\n\n"
 
 for interface in $(iw dev | awk '$1=="Interface"{print $2}'); do echo $interface; iw dev $interface get power_save; done


### PR DESCRIPTION
`iwconfig` is now deprecated and no longer exists on Fedora. It now causes the error `command not found: iwconfig` and "Signal quality" does not display a value.

Before (`iwconfig`):
```
The name of your wireless interface is: wlp166s0
Signal strength is: -36 dBm
wifi-fixer-bash-script.sh:33: command not found: iwconfig
Signal quality is: 


wlp166s0
Power save: on
Not connected to the default WAP.


Even if you have a working connection, check your Wi-Fi settings.
```

After (`nmcli`):
```
The name of your wireless interface is: wlp166s0
Signal strength is: -49 dBm
Signal quality is: 71/100


wlp166s0
Power save: on
Not connected to the default WAP.


Even if you have a working connection, check your Wi-Fi settings.
```